### PR TITLE
v1.8: EEL crash diagnostics, warp decay fix, blur scan, tex2D whitespace

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -4,7 +4,7 @@ Comparison of four MilkDrop-based music visualizer projects on Windows 11 x64.
 
 | Project | Description | Graphics API | Status |
 | ------- | ----------- | ------------ | ------ |
-| **MDropDX12** | Ground-up DX12 rebuild of MilkDrop2 engine | DirectX 12 | Active (v1.4) |
+| **MDropDX12** | Ground-up DX12 rebuild of MilkDrop2 engine | DirectX 12 | Active (v1.7.4) |
 | **Milkwave** | Remote control app + bundled MilkDrop2 visualizer | DirectX 9Ex | Active (v3.5) |
 | **MilkDrop3** | Enhanced MilkDrop2 fork (reference visualizer) | DirectX 9Ex | Active (v3.31) |
 | **projectM** | Open-source MilkDrop reimplementation (SDL standalone) | OpenGL | Pre-release (lib v4.1.6) |
@@ -37,6 +37,8 @@ Comparison of four MilkDrop-based music visualizer projects on Windows 11 x64.
 | On-the-fly device selection | ✅ | ✅ | ❌ | ✅ (Ctrl+A) |
 | Hi-res audio support | ✅ | ✅ | ✅ (v3.31) | ❌ |
 | Smooth audio variables (bass/mid/treb/vol_smooth) | ✅ | ✅ | ❌ | ❌ |
+| FFT EQ smoothing (attack/decay, peak hold) | ✅ | ❌ | ❌ | ❌ |
+| FFT shader functions (get_fft, get_fft_hz, get_fft_peak) | ✅ | ❌ | ❌ | ❌ |
 | Signal amplification | ✅ | ✅ | ❌ | ❌ |
 | Disable audio capture option | ✅ | ✅ | ❌ | ❌ |
 
@@ -46,6 +48,7 @@ Comparison of four MilkDrop-based music visualizer projects on Windows 11 x64.
 | ------- | --------- | -------- | --------- | -------- |
 | .milk preset loading | ✅ | ✅ | ✅ | ✅ |
 | .milk2 double-preset format | ✅ | ❌ | ✅ | ❌ |
+| .milk3 Shadertoy import (GLSL→HLSL) | ✅ | ❌ | ❌ | ❌ |
 | Preset browser (in-app) | ✅ | ✅ | ✅ | ❌ (WIP) |
 | Preset browser filtering (Ctrl+F) | ✅ | ✅ | ❌ | ❌ |
 | Preset tagging | ✅ | ✅ | ❌ | ❌ |
@@ -58,7 +61,7 @@ Comparison of four MilkDrop-based music visualizer projects on Windows 11 x64.
 | Preset change on track change | ✅ | ✅ | ❌ | ❌ |
 | Drag-and-drop preset loading | ✅ | ❌ | ❌ | ❌ |
 | Command-line / Explorer double-click loading | ✅ | ❌ | ❌ | ❌ |
-| Preset filter by type (.milk / .milk2) | ✅ | ❌ | ❌ | ❌ |
+| Preset filter by type (.milk / .milk2 / .milk3) | ✅ | ❌ | ❌ | ❌ |
 | Preset mode buttons (assign/recall) | ❌ | ✅ | ❌ | ❌ |
 | Deep mashup (multi-layer) | ❌ | ❌ | ✅ | ❌ |
 | Preset lock | ✅ | ✅ | ✅ | ✅ (Space) |
@@ -83,6 +86,8 @@ Comparison of four MilkDrop-based music visualizer projects on Windows 11 x64.
 | Shader editor tab | ❌ | ✅ | ❌ | ❌ |
 | MilkPanel shader editor | ❌ | ❌ | ✅ | ❌ |
 | Shader precompiling and caching | ✅ | ✅ | ✅ (v3.31) | ❌ |
+| SM5.0 (ps_5_0) for Shadertoy presets | ✅ | ❌ | ❌ | n/a |
+| GLSL→HLSL shader converter | ✅ | ❌ | ❌ | n/a |
 | HLSL variable shadowing fix | ✅ | ❌ | ❌ | n/a |
 | PSVersion=4 (AMD GPU support) | ✅ | ✅ | ❌ | n/a |
 | Shader randomize (!/@ keys) | ✅ | ✅ | ✅ | ❌ |
@@ -216,6 +221,8 @@ Comparison of four MilkDrop-based music visualizer projects on Windows 11 x64.
 | Device restart from settings UI | ✅ | ❌ | ❌ | ❌ |
 | Async compilation (prevents GPU stall) | ✅ | ❌ | ❌ | ❌ |
 | Shader compile timeout | ✅ | ❌ | ❌ | ❌ |
+| SEH crash protection (preset load/EEL JIT) | ✅ | ❌ | ❌ | ❌ |
+| EEL crash diagnostics (diag_eel_error.txt) | ✅ | ❌ | ❌ | ❌ |
 
 ## Settings & Configuration
 
@@ -231,13 +238,14 @@ Comparison of four MilkDrop-based music visualizer projects on Windows 11 x64.
 | Settings tab memory | ✅ | ❌ | ❌ | ❌ |
 | Game controller config UI | ✅ | ❌ (Remote-side) | ❌ | ❌ |
 | File association registration (.milk/.milk2) | ✅ | ❌ | ❌ | ❌ |
+| Error display settings (ToolWindow) | ✅ | ❌ | ❌ | ❌ |
 | Verbose logging (LogLevel=2) | ✅ | ✅ | ❌ | ❌ |
 
 ## Expression Evaluation
 
 | Feature | MDropDX12 | Milkwave | MilkDrop3 | projectM |
 | ------- | --------- | -------- | --------- | -------- |
-| ns-eel2 (native, x64 JIT) | ✅ | ❌ | ❌ | ❌ |
+| ns-eel2 (native, x64 JIT, SEH-protected) | ✅ | ❌ | ❌ | ❌ |
 | ns-eel2 (native, x86) | ❌ | ❌ | ✅ | ❌ |
 | projectM-eval (via ns-eel2 shim) | ❌ | ✅ | ❌ | ❌ |
 | projectM-eval (native) | ❌ | ❌ | ❌ | ✅ |
@@ -254,13 +262,17 @@ Milkwave Remote finds the Visualizer window using `EnumWindows()` + `GetWindowTe
 
 MilkDrop3 introduced `.milk2` files which contain two presets blended together with 19+ blend patterns. MDropDX12 also supports `.milk2` loading and blend transitions. Milkwave and projectM do not support this format.
 
+### .milk3 Shadertoy Import Format
+
+MDropDX12 introduced `.milk3`, a JSON format for importing Shadertoy shaders. The built-in GLSL→HLSL converter handles type replacement, matrix multiplication rewriting, and Shadertoy-specific uniforms (iResolution, iTime, iChannel0–3, iMouse). Supports multi-pass rendering (Buffer A → Buffer B → Image) with FLOAT32 ping-pong feedback buffers, SM5.0 shaders, and sRGB gamma correction. Common shader code can be shared across passes. No other MilkDrop-based visualizer supports Shadertoy import.
+
 ### projectM on Windows
 
 The projectM standalone visualizer ([frontend-sdl-cpp](https://github.com/projectM-visualizer/frontend-sdl-cpp)) is an SDL2-based application using the libprojectM rendering library (v4.1.6). On Windows it uses SDL audio capture rather than native WASAPI loopback, so it captures input devices (microphones) but does not capture desktop/system audio natively. The standalone app and its settings UI are still under active development (pre-release). projectM renders via OpenGL — it transpiles HLSL shader code from .milk presets to GLSL at runtime using an internal HLSL→GLSL transpiler (formerly Cg, now hlsltranslator). All .milk presets store HLSL shader bodies; no .milk presets in the wild use native GLSL. projectM does not implement sprites, the MilkDrop text message system, or Spout integration.
 
 ### Architectural Differences
 
-- **MDropDX12 v1.4**: DirectX 12, x64, native ns-eel2 (x64 JIT), GDI overlay for text, no DX9 half-texel offset, no projection matrix (clip-space passthrough); ToolWindow system (Settings, Displays, Song Info, Hotkeys, MIDI run on own threads), configurable hotkeys with local/global scope and dynamic Script/Launch entries, native MIDI input (50 mapping slots with learn mode), tri-mode theme (Dark/Light/Follow System with WM_SETTINGCHANGE auto-detection), native webcam/video file capture via Media Foundation, Spout input mixing via D3D11On12, monitor mirroring, game controller support, idle timer, window title regex parsing
+- **MDropDX12 v1.7.4**: DirectX 12, x64, native ns-eel2 (x64 JIT with SEH crash protection), GDI overlay for text, no DX9 half-texel offset, no projection matrix (clip-space passthrough); ToolWindow system (Settings, Displays, Song Info, Hotkeys, MIDI, Error Display run on own threads), configurable hotkeys with local/global scope and dynamic Script/Launch entries, native MIDI input (50 mapping slots with learn mode), tri-mode theme (Dark/Light/Follow System with WM_SETTINGCHANGE auto-detection), native webcam/video file capture via Media Foundation, Spout input mixing via D3D11On12, monitor mirroring, game controller support, idle timer, window title regex parsing, Shadertoy import with GLSL→HLSL converter and .milk3 JSON format (SM5.0, FLOAT32 ping-pong feedback buffers, Buffer A/B multi-pass), FFT EQ smoothing with attack/decay and peak hold, SEH crash diagnostics for EEL JIT and preset loading, self-bootstrapping exe with embedded shaders
 - **Milkwave v3.5**: Bundles a modified MilkDrop2 (DX9Ex) visualizer with a separate .NET 8 Remote control app; adds input mixing, game controller support, MIDI automation, projectM-eval expression engine
 - **MilkDrop3 v3.31**: DirectX 9Ex, x86, native ns-eel2 (x86), adds .milk2 format, MilkPanel shader editor, deep mashup system, expanded variable ranges, shader caching (v3.31), hi-res audio (v3.31), 5 sprite layers with blend modes
 - **projectM v4.1.6**: OpenGL, x64, cross-platform (Windows/macOS/Linux), projectM-eval expression engine, GLSL shader pipeline, SDL2 audio; reimplements MilkDrop2 rendering from scratch without using original MilkDrop2 code

--- a/src/mDropDX12/engine_shaders.cpp
+++ b/src/mDropDX12/engine_shaders.cpp
@@ -1367,7 +1367,36 @@ bool Engine::LoadShaderFromMemory(const char* szOrigShaderText, char* szFn, char
   // Replace tex2D/tex2Dlod calls for samplers that need non-default addressing modes.
   // The generic tex2D macro uses _samp_lw (LINEAR+WRAP). These replacements bypass
   // the macro by directly emitting .Sample() / .SampleLevel() with the correct sampler.
+  //
+  // First: normalize whitespace between tex2D/tex2Dlod/tex2Dbias and '(' so that
+  // "tex2D (sampler_pc_main, ...)" matches the replacement pattern.
+  // Some presets have spaces here (e.g. organic12-3d-2.milk), which would otherwise
+  // skip the replacement and fall through to the tex2D macro with the wrong sampler.
   {
+    const char* texFuncs[] = { "tex2Dlod", "tex2Dbias", "tex2D", "tex3Dlod", "tex3D" };
+    for (const char* fn : texFuncs) {
+      int fnLen = (int)strlen(fn);
+      char* p = szShaderText;
+      while ((p = strstr(p, fn)) != nullptr) {
+        // Ensure we're at a word boundary (not inside another identifier)
+        if (p > szShaderText) {
+          char prev = *(p - 1);
+          if ((prev >= 'a' && prev <= 'z') || (prev >= 'A' && prev <= 'Z') || (prev >= '0' && prev <= '9') || prev == '_') {
+            p += fnLen;
+            continue;
+          }
+        }
+        char* after = p + fnLen;
+        // Count whitespace between function name and '('
+        int spaces = 0;
+        while (after[spaces] == ' ' || after[spaces] == '\t') spaces++;
+        if (spaces > 0 && after[spaces] == '(') {
+          // Collapse: shift everything left by 'spaces' chars
+          memmove(after, after + spaces, strlen(after + spaces) + 1);
+        }
+        p = after + 1;  // advance past the '('
+      }
+    }
     auto replaceTex2D = [&](const char* sampName, const char* sampState) {
       char from[80], to[80];
       // tex2D(sampler_name, ...) → sampler_name.Sample(sampState, ...)

--- a/src/mDropDX12/milkdropfs.cpp
+++ b/src/mDropDX12/milkdropfs.cpp
@@ -2337,6 +2337,7 @@ void mdrop::Engine::DX12_RenderWarpAndComposite()
     BuildBindingSlots(&m_shaders.warp.params, m_dx12VS[0], warpSlots);
 
     // Buffer A reads feedback[read] (own previous output), comp reads feedback[write] (Buffer A's current output)
+    // Comp always reads VS[1] = current frame's warp+shapes output
     if (m_bHasBufferA) {
       BuildBindingSlots(&m_shaders.bufferA.params, m_dx12VS[1], bufferASlots, &m_dx12Feedback[fbRead]);
       BuildBindingSlots(&m_shaders.comp.params, m_dx12VS[1], compSlots, &m_dx12Feedback[fbWrite]);
@@ -2420,11 +2421,25 @@ void mdrop::Engine::DX12_RenderWarpAndComposite()
     // Bind VS0 via per-frame binding block (main tex at correct t-register, null elsewhere)
     cmdList->SetGraphicsRootDescriptorTable(1, m_lpDX->GetWarpBindingGpuHandle());
 
-    // Compute decay color (modulates previous frame to create trail fade)
-    float fDecay = (float)(*m_pState->var_pf_decay);
-    D3DCOLOR cDecay = D3DCOLOR_RGBA_01(fDecay, fDecay, fDecay, 1);
+    // Vertex decay: In DX9's WarpedBlit_Shaders (shader warp path), vertex colors
+    // are NOT modulated by decay — the custom warp pixel shader handles decay itself.
+    // Only WarpedBlit_NoShaders (non-shader path) applies decay via vertex color, where
+    // the fixed-function pipeline multiplies texture color by vertex diffuse.
+    // In DX12, custom shaders ignore vertex color RGB (only _vDiffuse.w/alpha is used
+    // in the output wrapper), so applying decay to vertices would be harmless but wrong.
+    // For the fallback PSO (PSO_TEXTURED_MYVERTEX), vertex color IS used as a texture
+    // modulator, so decay must be applied there.
+    D3DCOLOR cDecay;
+    if (!m_dx12WarpPSO) {
+      // Non-shader path: apply decay via vertex color (matches DX9 WarpedBlit_NoShaders)
+      float fDecay = (float)(*m_pState->var_pf_decay);
+      cDecay = D3DCOLOR_RGBA_01(fDecay, fDecay, fDecay, 1);
+    } else {
+      // Shader path: keep vertex color white (matches DX9 WarpedBlit_Shaders)
+      cDecay = 0xFFFFFFFF;
+    }
 
-    // Expand warp mesh to triangle list (same logic as WarpedBlit_NoShaders)
+    // Expand warp mesh to triangle list
     int primCount = m_nGridX * m_nGridY * 2;
     int totalVerts = primCount * 3;
     MYVERTEX tempv[1024 * 3];
@@ -2437,9 +2452,6 @@ void mdrop::Engine::DX12_RenderWarpAndComposite()
       while (prims_queued < max_per_batch && src_idx < totalVerts) {
         for (int j = 0; j < 3; j++) {
           tempv[i++] = m_verts[m_indices_list[src_idx++]];
-          // Note: DX9 flips Y here to compensate for the OrthoLH(2,-2) projection.
-          // DX12 vertex shaders output directly to clip space (no projection), so
-          // Y flip is NOT needed.
           tempv[i - 1].Diffuse = (cDecay & 0x00FFFFFF) | (tempv[i - 1].Diffuse & 0xFF000000);
         }
         prims_queued++;
@@ -2453,14 +2465,17 @@ void mdrop::Engine::DX12_RenderWarpAndComposite()
   // ── Blur passes: build blur pyramid from VS0 (just-warped frame) ──
   // Must run after warp (which wrote VS1 from VS0) so that comp shaders
   // can sample blur textures via GetBlur1/2/3().
-  // Pre-scan comp shader's blur texture usage so blur passes cover both
-  // warp and comp needs (ApplyShaderParams for comp runs AFTER blur passes).
+  // Pre-scan both warp and comp shader blur texture usage so blur passes
+  // cover all needs (ApplyShaderParams for comp runs AFTER blur passes).
+  // Some presets use GetBlur1() in the warp shader (e.g. organic12-3d-2.milk).
   {
-    CShaderParams* cp = &m_shaders.comp.params;
-    for (int i = 0; i < 32; i++) {
-      if (cp->m_texcode[i] >= TEX_BLUR1 && cp->m_texcode[i] <= TEX_BLUR_LAST)
-        m_nHighestBlurTexUsedThisFrame = max(m_nHighestBlurTexUsedThisFrame,
-            ((int)cp->m_texcode[i] - (int)TEX_BLUR1) + 1);
+    CShaderParams* shaderParams[] = { &m_shaders.warp.params, &m_shaders.comp.params };
+    for (auto* sp : shaderParams) {
+      for (int i = 0; i < 32; i++) {
+        if (sp->m_texcode[i] >= TEX_BLUR1 && sp->m_texcode[i] <= TEX_BLUR_LAST)
+          m_nHighestBlurTexUsedThisFrame = max(m_nHighestBlurTexUsedThisFrame,
+              ((int)sp->m_texcode[i] - (int)TEX_BLUR1) + 1);
+      }
     }
   }
   DX12_BlurPasses();


### PR DESCRIPTION
## Summary
- **EEL crash diagnostics**: Thread-local `EelCompileScope` tracks which EEL expression (preset_init, per_frame, wave_N_per_point, shape_N_init, etc.) is being compiled. On SEH crash, writes phase + source text + JIT detection to `diag_eel_error.txt` alongside existing `diag_seh_crash.txt`
- **Warp vertex decay fix**: Shader warp path now uses white vertex color (matching DX9 `WarpedBlit_Shaders`); only non-shader path applies decay via vertex diffuse
- **Blur texture scan**: Both warp AND comp shader params are now scanned for blur texture usage, fixing presets that use `GetBlur1()` in warp shaders (e.g. `organic12-3d-2.milk`)
- **tex2D whitespace normalization**: Collapses spaces between `tex2D`/`tex2Dlod`/`tex3D` and `(` so sampler replacement works for presets with `tex2D (sampler, ...)` syntax
- **Hue shader corner colors**: Comp fullscreen quad now computes animated hue_shader colors for all 4 corners
- **docs/comparison.md**: Updated to v1.7.4 with Shadertoy/.milk3, FFT EQ, SEH crash protection, and other features added since v1.4

## Test plan
- [ ] Load crashing preset (`Flexi - bouncing balls [double mindblob neon mix] Cubes2077.milk2`) — verify `diag_eel_error.txt` is written with phase/source
- [ ] Load `organic12-3d-2.milk` — verify blur and tex2D fixes (no black screen)
- [ ] Load hue_shader presets (e.g. `fiShbRaiN + Flexi - witchcraft`) — verify colorful output
- [ ] Run normal preset cycling — verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)