### PR TITLE
Fix global hotkeys not dispatching most actions

### DIFF
--- a/src/mDropDX12/App.cpp
+++ b/src/mDropDX12/App.cpp
@@ -1306,17 +1306,9 @@ LRESULT CALLBACK StaticWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPara
   case WM_HOTKEY:
   {
     int id = (int)wParam;
-    // Window-open actions: delegate to engine dispatch
-    if (id == HK_OPEN_SETTINGS || id == HK_OPEN_DISPLAYS ||
-        id == HK_OPEN_SONGINFO || id == HK_OPEN_HOTKEYS) {
-      g_engine.DispatchHotkeyAction(id);
-      break;
-    }
-    // Toggle actions: handle inline (need local hWnd/fullscreen state)
-    switch (id) {
-    case HK_TOGGLE_FULLSCREEN:
+    // Toggle actions need App.cpp locals (hWnd, fullscreen state)
+    if (id == HK_TOGGLE_FULLSCREEN) {
       if (g_engine.m_bMirrorsActive) {
-        // Mirroring → single fullscreen: disable mirrors, stay fullscreen
         g_engine.m_bMirrorsActive = false;
         g_engine.AddNotification(L"Mirror outputs disabled");
       } else {
@@ -1324,7 +1316,8 @@ LRESULT CALLBACK StaticWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPara
       }
       SetForegroundWindow(hWnd);
       break;
-    case HK_TOGGLE_STRETCH:
+    }
+    if (id == HK_TOGGLE_STRETCH) {
       if (g_engine.m_bMirrorModeForAltS) {
         if (!g_engine.m_bMirrorsActive) {
           auto result = g_engine.TryActivateMirrors(hWnd);
@@ -1348,6 +1341,8 @@ LRESULT CALLBACK StaticWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPara
       SetForegroundWindow(hWnd);
       break;
     }
+    // All other global hotkey actions: delegate to engine dispatch
+    g_engine.DispatchHotkeyAction(id);
     break;
   }
 


### PR DESCRIPTION
## Summary
- WM_HOTKEY handler in App.cpp only routed 4 hardcoded action IDs (settings, displays, songinfo, hotkeys) to `DispatchHotkeyAction()`, silently dropping all other global hotkey actions
- Now routes all non-toggle actions through the engine dispatcher
- Toggle fullscreen/stretch stay inline since they need App.cpp locals (hWnd, fullscreen state)

## Test plan
- [ ] Assign a global hotkey (e.g., Ctrl+Shift+Alt+P for presets)
- [ ] Switch focus to another application
- [ ] Press the global hotkey — should trigger the action
- [ ] Verify toggle fullscreen and toggle stretch still work as global hotkeys

🤖 Generated with [Claude Code](https://claude.com/claude-code)